### PR TITLE
Add minimal model server for predictive endpoint

### DIFF
--- a/scripts/model_server/README.md
+++ b/scripts/model_server/README.md
@@ -1,0 +1,12 @@
+# Model Server
+
+Minimal model server exposing a `/predict` endpoint.
+
+## Run
+
+```bash
+pip install -r requirements.txt
+uvicorn server:app --port 9000
+```
+
+Once running, strategies can query predictions at `http://127.0.0.1:9000/predict`.

--- a/scripts/model_server/requirements.txt
+++ b/scripts/model_server/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.111.0
+uvicorn[standard]==0.29.0
+torch==2.3.1
+numpy==1.26.4

--- a/scripts/model_server/server.py
+++ b/scripts/model_server/server.py
@@ -1,0 +1,37 @@
+import torch
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+
+class LSTMModel(torch.nn.Module):
+    """Minimal LSTM model with two outputs."""
+
+    def __init__(self, input_size: int = 1, hidden_size: int = 10):
+        super().__init__()
+        self.lstm = torch.nn.LSTM(input_size, hidden_size, batch_first=True)
+        self.linear = torch.nn.Linear(hidden_size, 2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        output, _ = self.lstm(x)
+        output = output[:, -1, :]
+        return self.linear(output)
+
+
+model = LSTMModel()
+model.eval()
+
+
+class PredictRequest(BaseModel):
+    data: list[float]
+
+
+app = FastAPI()
+
+
+@app.post("/predict")
+def predict(request: PredictRequest):
+    """Return p_up and vol_h predictions for provided sequence."""
+    x = torch.tensor(request.data, dtype=torch.float32).view(1, -1, 1)
+    with torch.no_grad():
+        pred = model(x).numpy()[0]
+    return {"p_up": float(pred[0]), "vol_h": float(pred[1])}


### PR DESCRIPTION
## Summary
- add model_server with FastAPI-based LSTM prediction endpoint
- document usage and pin dependencies for model server

## Testing
- `pre-commit run --files scripts/model_server/requirements.txt scripts/model_server/server.py scripts/model_server/README.md`
- `pytest test -q` *(fails: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68ac00b669088330b0f059626e1ded70